### PR TITLE
fix: rename crate to slack-blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "slack-block-kit"
+name = "slack-blocks"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
closes #11 