### PR TITLE
Don't serialize None as null

### DIFF
--- a/src/block_elements/button.rs
+++ b/src/block_elements/button.rs
@@ -33,14 +33,18 @@ pub struct Contents {
     #[validate(length(max = 255))]
     action_id: String,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 3000))]
     url: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 2000))]
     value: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     style: Option<Style>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     confirm: Option<()>, // FIX: doesn't exist yet
 }
 

--- a/src/blocks/actions.rs
+++ b/src/blocks/actions.rs
@@ -19,6 +19,7 @@ pub struct Contents {
     #[validate(length(max = 5))]
     elements: Vec<BlockElement>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 }

--- a/src/blocks/context.rs
+++ b/src/blocks/context.rs
@@ -19,6 +19,7 @@ pub struct Contents {
     #[validate(length(max = 10))]
     elements: Vec<Compose>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 }

--- a/src/blocks/file.rs
+++ b/src/blocks/file.rs
@@ -15,6 +15,7 @@ use crate::val_helpr::ValidationResult;
 pub struct Contents {
     external_id: String,
     source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 }

--- a/src/blocks/image.rs
+++ b/src/blocks/image.rs
@@ -19,9 +19,11 @@ pub struct Contents {
     #[validate(length(max = 2000))]
     alt_text: String,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate::title")]
     title: Option<text::Text>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 }

--- a/src/blocks/input.rs
+++ b/src/blocks/input.rs
@@ -23,12 +23,15 @@ pub struct Contents {
 
     element: InputElement,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate::hint")]
     hint: Option<text::Text>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional: Option<bool>,
 }
 

--- a/src/blocks/section.rs
+++ b/src/blocks/section.rs
@@ -25,19 +25,23 @@ use crate::val_helpr::ValidationResult;
 /// [block elements 🔗]: https://api.slack.com/reference/messaging/block-elements
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize, Validate)]
 pub struct Contents {
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 10))]
     #[validate(custom = "validate::fields")]
     fields: Option<Vec<text::Text>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate::text")]
     text: Option<text::Text>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(length(max = 255))]
     block_id: Option<String>,
 
     /// One of the available [element objects 🔗][element_objects].
     ///
     /// [element_objects]: https://api.slack.com/reference/messaging/block-elements
+    #[serde(skip_serializing_if = "Option::is_none")]
     accessory: Option<()>,
 }
 

--- a/src/compose/text/mrkdwn.rs
+++ b/src/compose/text/mrkdwn.rs
@@ -52,6 +52,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Hash, PartialEq, Serialize)]
 pub struct Contents {
     text: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     verbatim: Option<bool>,
 }
 

--- a/src/compose/text/plain.rs
+++ b/src/compose/text/plain.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Hash, PartialEq, Serialize)]
 pub struct Contents {
     text: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     emoji: Option<bool>,
 }
 

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -13,7 +13,10 @@ macro_rules! happy_json_test {
             let actual = serde_json::from_value($test_data.clone()).unwrap();
 
             // assert
-            assert_eq!(matches!(actual, $matches), true)
+            assert_eq!(matches!(actual, $matches), true);
+
+            let serialized = serde_json::to_string(&actual).unwrap();
+            assert!(!serialized.contains("null"));
         }
     };
 }


### PR DESCRIPTION
Fixes https://github.com/cakekindel/slack-blocks-rs/issues/109

Let me know what you think of `check_no_nulls`. At first I had it just panic inside if it encountered a null - but then I realized it would be difficult to actually track down where a null was introduced, hence the check within the macro and logging of the serialized value if it fails.