### PR TITLE
feat!: rename mox->blox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["slack", "messages", "models", "ergonomic", "fully-documented"]
 categories = ["data-structures"]
 
 [features]
-unstable = ["xml", "validation"]
-xml = ["mox"]
+unstable = ["blox", "validation"]
+blox = ["mox"]
 validation = []
 
 [package.metadata.docs.rs]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,15 +28,15 @@ dependencies = ["install-fmt"]
 
 [tasks.doctest-slow]
 command = "cargo"
-args = ["--locked", "test", "--features", "xml", "--jobs", "1", "--doc", "--", "--quiet"]
+args = ["--locked", "test", "--features", "blox", "--jobs", "1", "--doc", "--", "--quiet"]
 
 [tasks.doctest]
 command = "cargo"
-args = ["--locked", "test", "--features", "xml", "--doc", "--", "--quiet"]
+args = ["--locked", "test", "--features", "blox", "--doc", "--", "--quiet"]
 
 [tasks.test]
 command = "cargo"
-args = ["--locked", "test", "--features", "xml", "--tests", "--", "--quiet"]
+args = ["--locked", "test", "--features", "blox", "--tests", "--", "--quiet"]
 dependencies = ["doctest"]
 
 [tasks.tdd]

--- a/src/blocks/actions.rs
+++ b/src/blocks/actions.rs
@@ -161,6 +161,8 @@ pub mod build {
     /// Invoked by `blox!` when a child element is passed to `<actions_block>`.
     ///
     /// Alias of `ActionsBuilder.element`.
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<El>(self,
                      element: El)
                      -> ActionsBuilder<'a, Set<method::elements>>

--- a/src/blocks/context.rs
+++ b/src/blocks/context.rs
@@ -127,8 +127,8 @@ pub mod build {
     }
 
     /// Alias of `element` for appending an element with an XML child.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<El>(self,
                      element: El)
                      -> ContextBuilder<'a, Set<method::elements>>

--- a/src/blocks/input.rs
+++ b/src/blocks/input.rs
@@ -265,8 +265,8 @@ pub mod build {
     }
 
     /// XML child alias for `element`
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<El>(self,
                      element: El)
                      -> InputBuilder<'a, Set<method::element>, L>

--- a/src/blocks/section.rs
+++ b/src/blocks/section.rs
@@ -229,10 +229,9 @@ pub mod build {
     ///
     /// To set `text`, use the `text` attribute.
     /// ```
-    /// use mox::mox;
-    /// use slack_blocks::{blocks::Section, mox::*, text, text::ToSlackPlaintext};
+    /// use slack_blocks::{blocks::Section, blox::*, text, text::ToSlackPlaintext};
     ///
-    /// let xml = mox! {
+    /// let xml = blox! {
     ///   <section_block text={"Section".plaintext()}>
     ///     <text kind=plain>"Foo"</text>
     ///     <text kind=plain>"Bar"</text>
@@ -246,8 +245,8 @@ pub mod build {
     ///
     /// assert_eq!(xml, equiv);
     /// ```
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<T>(self, text: T) -> SectionBuilder<'a, Set<method::text>>
       where T: Into<text::Text>
     {

--- a/src/blox.rs
+++ b/src/blox.rs
@@ -37,7 +37,7 @@ mod blox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Actions, elems::Button, blox::*, text};
+  /// use slack_blocks::{blocks::Actions, blox::*, elems::Button, text};
   ///
   /// let xml = blox! {
   ///   <actions_block>
@@ -97,7 +97,7 @@ mod blox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Input, elems::TextInput, blox::*, text};
+  /// use slack_blocks::{blocks::Input, blox::*, elems::TextInput, text};
   ///
   /// let xml = blox! {
   ///   <input_block label="foo">
@@ -123,7 +123,7 @@ mod blox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Context, elems::Image, blox::*, text};
+  /// use slack_blocks::{blocks::Context, blox::*, elems::Image, text};
   ///
   /// let xml = blox! {
   ///   <context_block>
@@ -203,7 +203,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::TextInput, blox::*};
+  /// use slack_blocks::{blox::*, elems::TextInput};
   ///
   /// let xml: TextInput = blox! {
   ///   <text_input action_id="name_input"
@@ -235,7 +235,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::Image, blox::*};
+  /// use slack_blocks::{blox::*, elems::Image};
   ///
   /// let xml: Image = blox! {
   ///   <img src="https://foo.com/bar.png" alt="a pic of bar" />
@@ -258,7 +258,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::Button, blox::*};
+  /// use slack_blocks::{blox::*, elems::Button};
   ///
   /// let xml: Button = blox! {
   ///   <button action_id="click_me">"Click me!"</button>
@@ -281,7 +281,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, elems::Checkboxes, blox::*};
+  /// use slack_blocks::{blox::*, compose::Opt, elems::Checkboxes};
   ///
   /// let xml: Checkboxes = blox! {
   ///   <checkboxes action_id="chex">
@@ -325,7 +325,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::DatePicker, blox::*};
+  /// use slack_blocks::{blox::*, elems::DatePicker};
   ///
   /// let xml = blox! {
   ///   <date_picker action_id="pick_birthday" placeholder="Pick your birthday!" />
@@ -351,7 +351,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, elems::Overflow, blox::*};
+  /// use slack_blocks::{blox::*, compose::Opt, elems::Overflow};
   ///
   /// let xml = blox! {
   ///   <overflow action_id="menu">
@@ -383,7 +383,7 @@ mod blox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Input, compose::Opt, elems::Radio, blox::*};
+  /// use slack_blocks::{blocks::Input, blox::*, compose::Opt, elems::Radio};
   ///
   /// let xml = blox! {
   ///   <input_block label="Pick your favorite cheese!">
@@ -511,7 +511,7 @@ mod blox_compose {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, blox::*};
+  /// use slack_blocks::{blox::*, compose::Opt};
   ///
   /// let xml = blox! {
   ///   <option value="foo">
@@ -540,8 +540,8 @@ mod blox_compose {
   ///
   /// ## Example - Options known at compile-time
   /// ```
-  /// use slack_blocks::{compose::{Opt, OptGroup},
-  ///                    blox::*};
+  /// use slack_blocks::{blox::*,
+  ///                    compose::{Opt, OptGroup}};
   ///
   /// let xml = blox! {
   ///   <option_group label="foos_and_bars">
@@ -564,8 +564,8 @@ mod blox_compose {
   ///
   /// ## Example - Dynamic vec of options
   /// ```
-  /// use slack_blocks::{compose::{Opt, OptGroup},
-  ///                    blox::*};
+  /// use slack_blocks::{blox::*,
+  ///                    compose::{Opt, OptGroup}};
   ///
   /// # fn uuid() -> String {"foo".to_string()}
   /// # fn random_word() -> String {"foo".to_string()}
@@ -606,7 +606,7 @@ mod blox_compose {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Confirm, blox::*, text::ToSlackPlaintext};
+  /// use slack_blocks::{blox::*, compose::Confirm, text::ToSlackPlaintext};
   ///
   /// let xml = blox! {
   ///   <confirm title="Title"

--- a/src/blox.rs
+++ b/src/blox.rs
@@ -1,7 +1,4 @@
-//! # XML macro support
-//!
-//! This module provides shorthands for builder functions
-//! to be used with `mox` or a similar "xml -> Builder" macro.
+//! # XML macro builder support
 
 pub use elems::{button::Style::{Danger as btn_danger,
                                 Primary as btn_primary},
@@ -26,11 +23,11 @@ pub trait IntoChild: Sized {
 
 impl<T> IntoChild for T {}
 
-pub use mox_blocks::*;
-pub use mox_compose::*;
-pub use mox_elems::*;
+pub use blox_blocks::*;
+pub use blox_compose::*;
+pub use blox_elems::*;
 
-mod mox_blocks {
+mod blox_blocks {
   use super::*;
 
   /// # Build an actions block
@@ -40,7 +37,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Actions, elems::Button, mox::*, text};
+  /// use slack_blocks::{blocks::Actions, elems::Button, blox::*, text};
   ///
   /// let xml = blox! {
   ///   <actions_block>
@@ -74,7 +71,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Section, mox::*, text};
+  /// use slack_blocks::{blocks::Section, blox::*, text};
   ///
   /// let xml = blox! {
   ///   <section_block text=blox!{<text kind=plain>"Foo"</text>} />
@@ -100,7 +97,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Input, elems::TextInput, mox::*, text};
+  /// use slack_blocks::{blocks::Input, elems::TextInput, blox::*, text};
   ///
   /// let xml = blox! {
   ///   <input_block label="foo">
@@ -126,7 +123,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Context, elems::Image, mox::*, text};
+  /// use slack_blocks::{blocks::Context, elems::Image, blox::*, text};
   ///
   /// let xml = blox! {
   ///   <context_block>
@@ -158,7 +155,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::File, mox::*};
+  /// use slack_blocks::{blocks::File, blox::*};
   ///
   /// let xml = blox! {
   ///   <file_block external_id="foo" />
@@ -179,7 +176,7 @@ mod mox_blocks {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Image, mox::*};
+  /// use slack_blocks::{blocks::Image, blox::*};
   ///
   /// let xml = blox! {
   ///   <img_block src="https://foo.com/bar.png" alt="a pic of bar" />
@@ -196,7 +193,7 @@ mod mox_blocks {
   }
 }
 
-mod mox_elems {
+mod blox_elems {
   use super::*;
 
   /// # Build an text input element
@@ -206,7 +203,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::TextInput, mox::*};
+  /// use slack_blocks::{elems::TextInput, blox::*};
   ///
   /// let xml: TextInput = blox! {
   ///   <text_input action_id="name_input"
@@ -238,7 +235,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::Image, mox::*};
+  /// use slack_blocks::{elems::Image, blox::*};
   ///
   /// let xml: Image = blox! {
   ///   <img src="https://foo.com/bar.png" alt="a pic of bar" />
@@ -261,7 +258,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::Button, mox::*};
+  /// use slack_blocks::{elems::Button, blox::*};
   ///
   /// let xml: Button = blox! {
   ///   <button action_id="click_me">"Click me!"</button>
@@ -284,7 +281,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, elems::Checkboxes, mox::*};
+  /// use slack_blocks::{compose::Opt, elems::Checkboxes, blox::*};
   ///
   /// let xml: Checkboxes = blox! {
   ///   <checkboxes action_id="chex">
@@ -328,7 +325,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{elems::DatePicker, mox::*};
+  /// use slack_blocks::{elems::DatePicker, blox::*};
   ///
   /// let xml = blox! {
   ///   <date_picker action_id="pick_birthday" placeholder="Pick your birthday!" />
@@ -354,7 +351,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, elems::Overflow, mox::*};
+  /// use slack_blocks::{compose::Opt, elems::Overflow, blox::*};
   ///
   /// let xml = blox! {
   ///   <overflow action_id="menu">
@@ -386,7 +383,7 @@ mod mox_elems {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Input, compose::Opt, elems::Radio, mox::*};
+  /// use slack_blocks::{blocks::Input, compose::Opt, elems::Radio, blox::*};
   ///
   /// let xml = blox! {
   ///   <input_block label="Pick your favorite cheese!">
@@ -423,8 +420,8 @@ mod mox_elems {
   /// # Build a select menu
   ///
   /// # Attributes
-  /// - `kind` (Optional): `single` or `multi` from `slack_blocks::mox`. Default is `single`.
-  /// - `choose_from` (Required): `users`, `public_channels`, `static_`, `external`, `conversations` from `slack_blocks::mox`
+  /// - `kind` (Optional): `single` or `multi` from `slack_blocks::blox`. Default is `single`.
+  /// - `choose_from` (Required): `users`, `public_channels`, `static_`, `external`, `conversations` from `slack_blocks::blox`
   ///
   /// # Children
   /// For `static_`, 1-100 `<option>` children are allowed.
@@ -439,7 +436,7 @@ mod mox_elems {
   /// # Example - Select many Users
   /// ```
   /// use slack_blocks::elems::select;
-  /// use slack_blocks::mox::*;
+  /// use slack_blocks::blox::*;
   ///
   /// let xml = blox! {
   ///   <select kind=multi choose_from=users placeholder="Pick some users!" action_id="foo" />
@@ -452,7 +449,7 @@ mod mox_elems {
   ///
   /// # Example - Select an option from a list defined by your app
   /// ```
-  /// use slack_blocks::{elems::select, compose::Opt, mox::*};
+  /// use slack_blocks::{elems::select, compose::Opt, blox::*};
   ///
   /// let xml = blox! {
   ///   <select choose_from=static_ placeholder="Pick your favorite cheese!" action_id="foo">
@@ -478,7 +475,7 @@ mod mox_elems {
   }
 }
 
-mod mox_compose {
+mod blox_compose {
   use super::*;
 
   /// # Text
@@ -490,7 +487,7 @@ mod mox_compose {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{blocks::Section, mox::*, text};
+  /// use slack_blocks::{blocks::Section, blox::*, text};
   ///
   /// let xml = blox! {
   ///   <text kind=plain>"Foo"</text>
@@ -514,7 +511,7 @@ mod mox_compose {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Opt, mox::*};
+  /// use slack_blocks::{compose::Opt, blox::*};
   ///
   /// let xml = blox! {
   ///   <option value="foo">
@@ -544,7 +541,7 @@ mod mox_compose {
   /// ## Example - Options known at compile-time
   /// ```
   /// use slack_blocks::{compose::{Opt, OptGroup},
-  ///                    mox::*};
+  ///                    blox::*};
   ///
   /// let xml = blox! {
   ///   <option_group label="foos_and_bars">
@@ -568,7 +565,7 @@ mod mox_compose {
   /// ## Example - Dynamic vec of options
   /// ```
   /// use slack_blocks::{compose::{Opt, OptGroup},
-  ///                    mox::*};
+  ///                    blox::*};
   ///
   /// # fn uuid() -> String {"foo".to_string()}
   /// # fn random_word() -> String {"foo".to_string()}
@@ -609,7 +606,7 @@ mod mox_compose {
   ///
   /// ## Example
   /// ```
-  /// use slack_blocks::{compose::Confirm, mox::*, text::ToSlackPlaintext};
+  /// use slack_blocks::{compose::Confirm, blox::*, text::ToSlackPlaintext};
   ///
   /// let xml = blox! {
   ///   <confirm title="Title"

--- a/src/compose/opt.rs
+++ b/src/compose/opt.rs
@@ -316,10 +316,9 @@ pub mod build {
   impl<'a, V, U> OptBuilder<'a, RequiredMethodNotCalled<method::text>, V, U> {
     /// Alias for `text`, allowing you to set the text of the option like so:
     /// ```
-    /// use mox::mox;
-    /// use slack_blocks::{compose::Opt, mox::*, text};
+    /// use slack_blocks::{compose::Opt, blox::*, text};
     ///
-    /// let xml = mox! {
+    /// let xml = blox! {
     ///   <option value="foo">
     ///     <text kind=plain>"Foo"</text>
     ///   </option>
@@ -331,8 +330,8 @@ pub mod build {
     ///
     /// assert_eq!(xml, equiv)
     /// ```
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<T: Into<text::Text>>(
       self,
       text: T)

--- a/src/compose/opt.rs
+++ b/src/compose/opt.rs
@@ -316,7 +316,7 @@ pub mod build {
   impl<'a, V, U> OptBuilder<'a, RequiredMethodNotCalled<method::text>, V, U> {
     /// Alias for `text`, allowing you to set the text of the option like so:
     /// ```
-    /// use slack_blocks::{compose::Opt, blox::*, text};
+    /// use slack_blocks::{blox::*, compose::Opt, text};
     ///
     /// let xml = blox! {
     ///   <option value="foo">

--- a/src/compose/opt_group.rs
+++ b/src/compose/opt_group.rs
@@ -260,8 +260,8 @@ pub mod build {
     }
 
     /// XML child alias for `option`.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<T2, U2>(
       self,
       option: Opt<'a, T2, U2>)
@@ -281,8 +281,8 @@ pub mod build {
     }
 
     /// XML child alias for `option`.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child(self, option: Opt<'a, T, U>) -> Self {
       self.option(option)
     }

--- a/src/compose/text/mod.rs
+++ b/src/compose/text/mod.rs
@@ -110,8 +110,8 @@ pub mod build {
 
   /// "Text Kind" for XML macro
   #[allow(non_camel_case_types)]
-  #[cfg(feature = "xml")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+  #[cfg(feature = "blox")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
   pub mod kind {
     use super::*;
     // This trick is kind of nasty. Essentially, I want the API to look like
@@ -229,21 +229,20 @@ pub mod build {
     /// to be set as a string literal instead of an attribute.
     ///
     /// ```
-    /// use mox::mox;
-    /// use slack_blocks::mox::*;
+    /// use slack_blocks::blox::*;
     ///
-    /// let as_attr = mox! {
+    /// let as_attr = blox! {
     ///   <text kind=plain text="Foo" />
     /// };
     ///
-    /// let as_child = mox! {
+    /// let as_child = blox! {
     ///   <text kind=plain>"Foo"</text>
     /// };
     ///
     /// assert_eq!(as_attr, as_child);
     /// ```
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child(self,
                  t: impl AsRef<str>)
                  -> TextBuilder<T, Set<method::text>> {
@@ -257,17 +256,16 @@ pub mod build {
     /// Intended to be used as an XML attribute with `build::kind::mrkdwn` or `build::kind::plain`
     ///
     /// ```
-    /// use mox::mox;
-    /// use slack_blocks::{mox::*, text};
+    /// use slack_blocks::{blox::*, text};
     ///
-    /// let xml = mox! {<text kind=plain>"Foo"</text>};
+    /// let xml = blox! {<text kind=plain>"Foo"</text>};
     ///
     /// let builder = text::Plain::from("Foo");
     ///
     /// assert_eq!(xml, builder)
     /// ```
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn kind<T, K>(self, kind: K) -> TextBuilder<T, M>
       where T: Into<Text>,
             K: kind::TextKind<T>

--- a/src/elems/button.rs
+++ b/src/elems/button.rs
@@ -255,8 +255,8 @@ pub mod build {
     }
 
     /// Alias for `text`
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child(self,
                  text: impl Into<text::Plain>)
                  -> ButtonBuilder<'a, Set<method::text>, A> {

--- a/src/elems/checkboxes.rs
+++ b/src/elems/checkboxes.rs
@@ -226,8 +226,8 @@ pub mod build {
     }
 
     /// Append an `option` to `options`
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<T: Into<text::Text>>(
       self,
       option: Opt<'a, T, NoUrl>)

--- a/src/elems/overflow.rs
+++ b/src/elems/overflow.rs
@@ -233,8 +233,8 @@ pub mod build {
     }
 
     /// Allows using an XML child to append an option.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<U>(self,
                     option: Opt<'a, text::Plain, U>)
                     -> OverflowBuilder<'a, A, Set<method::options>> {

--- a/src/elems/radio.rs
+++ b/src/elems/radio.rs
@@ -252,8 +252,8 @@ pub mod build {
     }
 
     /// Allows using XML children to append options to the group.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<T2: Into<text::Text>>(
       self,
       opt: Opt<'a, T2, NoUrl>)

--- a/src/elems/select/mod.rs
+++ b/src/elems/select/mod.rs
@@ -38,8 +38,8 @@ pub use static_::Static;
 pub use user::User;
 
 /// Select builder
-#[cfg(feature = "xml")]
-#[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+#[cfg(feature = "blox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
 pub mod build {
   use std::marker::PhantomData;
 

--- a/src/elems/select/static_.rs
+++ b/src/elems/select/static_.rs
@@ -193,8 +193,8 @@ pub mod build {
 
   /// Allows the builder to statically take in "either an opt or opt group" and
   /// enforce that the same type is used as a child later.
-  #[cfg(feature = "xml")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+  #[cfg(feature = "blox")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
   pub trait AppendOptOrOptGroup<'a, Multi, Placeholder, ActionId> {
     /// The builder state after adding the opt / opt group
     type Output;
@@ -209,8 +209,8 @@ pub mod build {
               -> Self::Output;
   }
 
-  #[cfg(feature = "xml")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+  #[cfg(feature = "blox")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
   impl<'a, Multi, Placeholder, ActionId>
     AppendOptOrOptGroup<'a, Multi, Placeholder, ActionId>
     for Opt<'a, text::Plain, NoUrl>
@@ -231,8 +231,8 @@ pub mod build {
     }
   }
 
-  #[cfg(feature = "xml")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+  #[cfg(feature = "blox")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
   impl<'a, Multi, Placeholder, ActionId>
     AppendOptOrOptGroup<'a, Multi, Placeholder, ActionId>
     for OptGroup<'a, text::Plain, NoUrl>
@@ -457,8 +457,8 @@ pub mod build {
     /// The type signature trickery here infers whether you've passed
     /// an Opt or OptGroup, and will ensure the following children will
     /// be the same type.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child<Opt>(self, child: Opt) -> Opt::Output
       where Opt: AppendOptOrOptGroup<'a, M, P, A>
     {
@@ -533,8 +533,8 @@ pub mod build {
     }
 
     /// Append an Opt as a child XML element.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child(self, option: impl Into<StaticOpt<'a>>) -> Self {
       self.option(option)
     }
@@ -554,8 +554,8 @@ pub mod build {
     }
 
     /// Append an OptGroup as a child XML element.
-    #[cfg(feature = "xml")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
+    #[cfg(feature = "blox")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
     pub fn child(self, option: impl Into<StaticOptGroup<'a>>) -> Self {
       self.option_group(option)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! Or enable the `unstable` feature and use xml macros:
 //! ```rust
-//! use slack_blocks::mox::*;
+//! use slack_blocks::blox::*;
 //!
 //! let pick_date = blox! {
 //!   <date_picker action_id="datepicker123"
@@ -84,9 +84,9 @@
 #[macro_use]
 extern crate validator_derive;
 
-#[cfg(feature = "xml")]
-#[cfg_attr(docsrs, doc(cfg(feature = "xml")))]
-pub mod mox;
+#[cfg(feature = "blox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blox")))]
+pub mod blox;
 
 #[doc(inline)]
 pub mod blocks;

--- a/tests/json/blocks/actions.rs
+++ b/tests/json/blocks/actions.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*};
+use slack_blocks::{blocks, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/blocks/context.rs
+++ b/tests/json/blocks/context.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*};
+use slack_blocks::{blocks, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/blocks/file.rs
+++ b/tests/json/blocks/file.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*};
+use slack_blocks::{blocks, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/blocks/image.rs
+++ b/tests/json/blocks/image.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*};
+use slack_blocks::{blocks, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/blocks/input.rs
+++ b/tests/json/blocks/input.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*};
+use slack_blocks::{blocks, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/blocks/section.rs
+++ b/tests/json/blocks/section.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*, text::ToSlackMarkdown};
+use slack_blocks::{blocks, blox::*, text::ToSlackMarkdown};
 
 #[test]
 pub fn all_attributes() {

--- a/tests/json/compose/confirm.rs
+++ b/tests/json/compose/confirm.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{mox::*, text::ToSlackMarkdown};
+use slack_blocks::{blox::*, text::ToSlackMarkdown};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/compose/option.rs
+++ b/tests/json/compose/option.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{blocks, mox::*, text::ToSlackMarkdown};
+use slack_blocks::{blocks, blox::*, text::ToSlackMarkdown};
 
 #[test]
 pub fn option_docs_ex_1() {

--- a/tests/json/compose/text.rs
+++ b/tests/json/compose/text.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{mox::*, text};
+use slack_blocks::{blox::*, text};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/button.rs
+++ b/tests/json/elems/button.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*};
+use slack_blocks::{blox::*, elems};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/button.rs
+++ b/tests/json/elems/button.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*};
+use slack_blocks::{elems, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/checkboxes.rs
+++ b/tests/json/elems/checkboxes.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*, text::ToSlackPlaintext};
+use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/checkboxes.rs
+++ b/tests/json/elems/checkboxes.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
+use slack_blocks::{blox::*, elems, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/date_picker.rs
+++ b/tests/json/elems/date_picker.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*, text::ToSlackPlaintext};
+use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/date_picker.rs
+++ b/tests/json/elems/date_picker.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
+use slack_blocks::{blox::*, elems, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/image.rs
+++ b/tests/json/elems/image.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*};
+use slack_blocks::{blox::*, elems};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/image.rs
+++ b/tests/json/elems/image.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*};
+use slack_blocks::{elems, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/overflow.rs
+++ b/tests/json/elems/overflow.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*, text::ToSlackPlaintext};
+use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/overflow.rs
+++ b/tests/json/elems/overflow.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
+use slack_blocks::{blox::*, elems, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/radio.rs
+++ b/tests/json/elems/radio.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*, text::ToSlackPlaintext};
+use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/radio.rs
+++ b/tests/json/elems/radio.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*, text::ToSlackPlaintext};
+use slack_blocks::{blox::*, elems, text::ToSlackPlaintext};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/conversation.rs
+++ b/tests/json/elems/select/conversation.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, blox::*};
+use slack_blocks::{blox::*, elems::BlockElement};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/conversation.rs
+++ b/tests/json/elems/select/conversation.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, mox::*};
+use slack_blocks::{elems::BlockElement, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/external.rs
+++ b/tests/json/elems/select/external.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, blox::*};
+use slack_blocks::{blox::*, elems::BlockElement};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/external.rs
+++ b/tests/json/elems/select/external.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, mox::*};
+use slack_blocks::{elems::BlockElement, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/public_channel.rs
+++ b/tests/json/elems/select/public_channel.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, blox::*};
+use slack_blocks::{blox::*, elems::BlockElement};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/public_channel.rs
+++ b/tests/json/elems/select/public_channel.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, mox::*};
+use slack_blocks::{elems::BlockElement, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/static_.rs
+++ b/tests/json/elems/select/static_.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, blox::*};
+use slack_blocks::{blox::*, elems::BlockElement};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/static_.rs
+++ b/tests/json/elems/select/static_.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, mox::*};
+use slack_blocks::{elems::BlockElement, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/user.rs
+++ b/tests/json/elems/select/user.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, blox::*};
+use slack_blocks::{blox::*, elems::BlockElement};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/select/user.rs
+++ b/tests/json/elems/select/user.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems::BlockElement, mox::*};
+use slack_blocks::{elems::BlockElement, blox::*};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/text_input.rs
+++ b/tests/json/elems/text_input.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, blox::*};
+use slack_blocks::{blox::*, elems};
 
 #[test]
 pub fn docs_ex_1() {

--- a/tests/json/elems/text_input.rs
+++ b/tests/json/elems/text_input.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use slack_blocks::{elems, mox::*};
+use slack_blocks::{elems, blox::*};
 
 #[test]
 pub fn docs_ex_1() {


### PR DESCRIPTION
sorry, this is something i realized would make more sense right after implementing and decided to do it along with the removal of deprecated functionality. I assume there are few library users right now so i'm getting in all the breaking v1.0.0 prep now.